### PR TITLE
[FEAT - Fixed header bug]

### DIFF
--- a/vawc-deskhub/src/screens/users/Settings.jsx
+++ b/vawc-deskhub/src/screens/users/Settings.jsx
@@ -9,7 +9,7 @@ export default function Settings() {
   const navigate = useNavigate();
   const user = JSON.parse(localStorage.getItem("user"));
 
-  const safeUser = user?.safeUser
+  const safeUser = user?.safeUser;
 
   return (
     <div className="montserrat-font flex min-h-screen bg-gray-50">
@@ -19,20 +19,20 @@ export default function Settings() {
       {/* Main Content */}
       <main className="flex-1 relative bg-white overflow-auto">
         {/* Header Image */}
-        <div className="relative h-48 rounded-b-lg flex justify-center items-center">
+        <div className="relative h-64 md:h-72 flex justify-center items-center z-0">
           <img
             src={bgUrl}
             alt="Header Background"
-            className="absolute inset-0 w-full h-full object-cover rounded-b-lg"
+            className="absolute inset-0 w-full h-full object-cover"
           />
-          <div className="absolute inset-0 bg-black bg-opacity-20 rounded-b-lg"></div>
-          <p className="relative z-10 text-white text-lg font-semibold drop-shadow">
+          <div className="absolute inset-0 bg-black/30"></div>
+          <p className="relative z-10 text-white text-2xl md:text-3xl font-semibold drop-shadow">
             Settings
           </p>
         </div>
 
         {/* Profile Section */}
-        <div className="max-w-5xl mx-auto bg-white rounded-xl shadow-md p-8 -mt-16 relative z-10 m-8">
+        <div className="max-w-5xl mx-auto bg-white rounded-xl shadow-md p-8 -mt-16 relative z-20 m-8">
           <div className="flex justify-between items-start mb-8">
             {/* Profile Info */}
             <div className="flex items-center space-x-4">


### PR DESCRIPTION
### The Bug:
In src/screens/users/Settings.jsx, the code for the background URL is:
` {/* Header Image */}
        <div className="relative h-48 rounded-b-lg flex justify-center items-center">
          <img
            src={bgUrl} //
            alt="Header Background"//
            className="absolute inset-0 w-full h-full object-cover rounded-b-lg"
          />
          <div className="absolute inset-0 bg-black bg-opacity-20 rounded-b-lg"></div>
          <p className="relative z-10 text-white text-lg font-semibold drop-shadow">
            Settings
          </p>
        </div>

        {/* Profile Section */}
        <div className="max-w-5xl mx-auto bg-white rounded-xl shadow-md p-8 -mt-16 relative z-10 m-8">`

- the header image container (div.relative.h-48) is only 192px tall (h-48), and your profile card section (div.max-w-5xl... -mt-16) is being pulled upward with a negative margin (-mt-16). which means white profile box is overlapping the header section

### The Fix:
` {/* Main Content */}
      <main className="flex-1 relative bg-white overflow-auto">
        {/* Header Image */}
        <div className="relative h-64 md:h-72 flex justify-center items-center z-0">
          <img
            src={bgUrl}//
            alt="Header Background"//
            className="absolute inset-0 w-full h-full object-cover"
          />
          <div className="absolute inset-0 bg-black/30"></div>
          <p className="relative z-10 text-white text-2xl md:text-3xl font-semibold drop-shadow">
            Settings
          </p>
        </div>

        {/* Profile Section */}
        <div className="max-w-5xl mx-auto bg-white rounded-xl shadow-md p-8 -mt-16 relative z-20 m-8">`

- Added z-0 to the header (to define a stacking context).
- Increased profile card’s z-index from z-10 to z-20.
- Ensured text stays visible (z-10 for “Settings”).

### Changed bg image:
## Before:

<img width="1852" height="1061" alt="Image" src="https://github.com/user-attachments/assets/1fc8fc87-2806-423a-81cf-d243651dc5f0" />

## After:

<img width="1849" height="1043" alt="Image" src="https://github.com/user-attachments/assets/ef3a42f3-041d-45fc-978f-adb01d414851" />